### PR TITLE
chore: remove inert claude.effort from .unleashed.json (Closes #13)

### DIFF
--- a/.unleashed.json
+++ b/.unleashed.json
@@ -1,8 +1,6 @@
 {
   "profile": "default",
-  "claude": {
-    "effort": "max"
-  },
+  "claude": {},
   "assemblyZero": false,
   "onboard": {
     "auto": true,


### PR DESCRIPTION
## Summary

Removes the inert `claude.effort` key from `.unleashed.json`. The Claude
wrapper no longer reads it; effort belongs to the operator's `effortLevel` user setting (a committed `.claude/settings.json` covers a deliberate per-repo pin). Sibling fields, key order, indent,
and line endings are preserved. No behavior change.

Filed and processed automatically by `tools/fleet_remove_claude_key.py`
in AssemblyZero.

Closes #13
